### PR TITLE
Update ar locale

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -23,7 +23,7 @@ const locales = {
   ae_ar: { ietf: 'ar-AE', tk: 'lpk1hwn.css', dir: 'rtl' },
   ae_en: { ietf: 'en', tk: 'hah7vzn.css' },
   africa: { ietf: 'en', tk: 'hah7vzn.css' },
-  ar: { ietf: 'ar', tk: 'lpk1hwn.css', dir: 'rtl' },
+  ar: { ietf: 'es-AR', tk: 'hah7vzn.css' },
   ar_es: { ietf: 'es-AR', tk: 'hah7vzn.css' },
   at: { ietf: 'de-AT', tk: 'hah7vzn.css' },
   au: { ietf: 'en-AU', tk: 'hah7vzn.css' },


### PR DESCRIPTION
Make the Argentina locale consistent with what our consumers are using. [Homepage](https://github.com/adobecom/homepage/blob/stage/homepage/scripts/scripts.js#L21), [CC](https://github.com/adobecom/cc/blob/stage/creativecloud/scripts/scripts.js#L23), [DC](https://github.com/adobecom/dc/blob/stage/acrobat/scripts/scripts.js#L144),  [Bacom](https://github.com/adobecom/bacom/blob/stage/scripts/scripts.js#L30) are all using this convention, since the Federal project tailors to them, it should also be consistent.

Test URLs:
* Before: https://main--federal--adobecom.hlx.page/ar/federal/globalnav/acom/sections/section-menu-cc-localnav
* After: https://update-ar-locale--federal--adobecom.hlx.page/ar/federal/globalnav/acom/sections/section-menu-cc-localnav