### PR TITLE
Update .hlxignore

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -2,4 +2,5 @@
 *.md
 LICENSE
 test/*
-!tools/sidekick/config.json
+*.json
+!*/**/*.json


### PR DESCRIPTION
The EDS team has requested that we remove root `.json` files from the code bus.

Links:

Before: [https://main--federal--adobecom.hlx.page/drafts/ramuntea/acom-gnav-thin](https://main--federal--adobecom.hlx.page/drafts/ramuntea/acom-gnav-thin)
After: [https://hlxignore-json-update--federal--adobecom.hlx.page/drafts/ramuntea/acom-gnav-thin](https://hlxignore-json-update--federal--adobecom.hlx.page/drafts/ramuntea/acom-gnav-thin)