### PR TITLE
hlx 5 support

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -19,10 +19,10 @@ export const [setLibs, getLibs] = (() => {
     (prodLibs, location) => {
       libs = (() => {
         const { hostname, search } = location || window.location;
-        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return prodLibs;
+        if (!(hostname.includes('.aem.') || hostname.includes('local'))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';
-        return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
+        return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
       })();
       return libs;
     }, () => libs,

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -4,7 +4,7 @@ import { setLibs } from '../../scripts/utils.js';
 describe('Libs', () => {
   it('Default Libs', () => {
     const libs = setLibs('/libs');
-    expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
+    expect(libs).to.equal('https://main--milo--adobecom.aem.live/libs');
   });
 
   it('Does not support milolibs query param on prod', () => {
@@ -22,7 +22,7 @@ describe('Libs', () => {
       search: '?milolibs=foo',
     };
     const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://foo--milo--adobecom.hlx.live/libs');
+    expect(libs).to.equal('https://foo--milo--adobecom.aem.live/libs');
   });
 
   it('Supports local milolibs query param', () => {
@@ -40,6 +40,6 @@ describe('Libs', () => {
       search: '?milolibs=awesome--milo--forkedowner',
     };
     const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://awesome--milo--forkedowner.hlx.live/libs');
+    expect(libs).to.equal('https://awesome--milo--forkedowner.aem.live/libs');
   });
 });

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,4 +1,6 @@
 {
+  "previewHost": "main--federal--adobecom.aem.page",
+  "liveHost": "main--federal--adobecom.aem.live",
   "plugins": [
     {
       "id": "library",
@@ -37,7 +39,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--federal--adobecom.hlx.page/tools/loc?milolibs=locui",
+      "url": "https://main--federal--adobecom.aem.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]


### PR DESCRIPTION
While this is a content repository, the links should still work

- Before: https://stage--federal--adobecom.aem.page/federal/dev/nishant/gnav
- After: https://hlx-5--federal--adobecom.aem.page/federal/dev/nishant/gnav