### PR TITLE
Update utils.js to suppport HLX4

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -19,7 +19,7 @@ export const [setLibs, getLibs] = (() => {
     (prodLibs, location) => {
       libs = (() => {
         const { hostname, search } = location || window.location;
-        if (!(hostname.includes('.aem.') || hostname.includes('local'))) return prodLibs;
+        if (!(hostname.includes('.hlx.') || hostname.includes('.aem.') || hostname.includes('local'))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';
         return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;


### PR DESCRIPTION
Ensure HLX4 is still supported for now.

URLs:
- Before: https://main--federal--adobecom.hlx.page/drafts/ramuntea/acom-gnav-thin?martech=off
- After: https://support-hlx-4--federal--adobecom.hlx.page/drafts/ramuntea/acom-gnav-thin?martech=off