### PR TITLE
Adding styles support for global navigation

### DIFF
--- a/libs/global-navigation/build.js
+++ b/libs/global-navigation/build.js
@@ -3,6 +3,26 @@ import { execSync } from 'child_process';
 
 const isWatch = process.argv.includes('--watch');
 
+// Plugin to inject CSS into JS
+const injectCSSPlugin = {
+  name: 'inject-css',
+  setup(build) {
+    build.onLoad({ filter: /\.css$/ }, async (args) => {
+      const fs = await import('fs/promises');
+      const css = await fs.readFile(args.path, 'utf8');
+
+      const contents = `
+        const css = ${JSON.stringify(css)};
+        const style = document.createElement('style');
+        style.textContent = css;
+        document.head.appendChild(style);
+      `;
+
+      return { contents, loader: 'js' };
+    });
+  },
+};
+
 const buildOptions = {
   entryPoints: ['src/Main.ts'],
   bundle: true,
@@ -13,24 +33,28 @@ const buildOptions = {
   minify: true,
   sourcemap: true,
   logLevel: 'info',
+  plugins: [injectCSSPlugin],
 };
 
 if (isWatch) {
   const context = await esbuild.context({
     ...buildOptions,
-    plugins: [{
-      name: 'type-check',
-      setup(build) {
-        build.onStart(() => {
-          execSync('tsc --noEmit', { stdio: 'inherit' });
-        });
+    plugins: [
+      {
+        name: 'type-check',
+        setup(build) {
+          build.onStart(() => {
+            execSync('tsc --noEmit', { stdio: 'inherit' });
+          });
+        },
       },
-    }],
+    injectCSSPlugin,
+    ],
   });
   await context.watch();
 } else {
   execSync('tsc --noEmit', { stdio: 'inherit' });
   
   await esbuild.build(buildOptions);
-  console.log('Build complete');
+  console.log('Build complete - CSS inlined into main.js');
 }

--- a/libs/global-navigation/src/Main.ts
+++ b/libs/global-navigation/src/Main.ts
@@ -9,7 +9,7 @@ import { initKeyboardNav } from "./PostRendering/Keyboard";
 import { UnavConfig } from "./PostRendering/Unav";
 import { getInitialHTML } from "./PreRendering/FetchAssets";
 import { renderListItems } from "./Utils/Utils";
-
+import './styles/styles.css';
 
 type GlobalNavigation = {
   closeEverything: () => void;
@@ -67,6 +67,7 @@ mountpoint: HTMLElement
 ): Promise<HTMLElement> => {
   const navHTML = renderGnavString(data)
   mountpoint.innerHTML = navHTML;
+  mountpoint.classList.add('site-pivot');
   const megaMenus = [
     ...mountpoint.querySelectorAll('.mega-menu ~ .feds-popup > ul')
   ]

--- a/libs/global-navigation/src/styles/styles.css
+++ b/libs/global-navigation/src/styles/styles.css
@@ -1,0 +1,14 @@
+
+/**
+ * Global Navigation Styles
+ * Styles for the federal global navigation component
+ */
+
+/* ========================================
+   Header Container
+   ======================================== */
+
+   header.global-navigation.site-pivot {
+    display: block;
+    visibility: visible;
+  }


### PR DESCRIPTION
- Added a css file under styles/global-navigation
- This CSS file is imported in Main.ts and automatically bundled into main.js during the build process.
- When main.js loads in the browser, the CSS is dynamically injected into a <style> tag in the document head.
- This approach allows consumers to import a single JavaScript file that includes both functionality and styling.